### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for [TriliumNext](https://github.com/TriliumNext/Trilium), providing AI assistants with seamless access to your note-taking workflow.
 
+<a href="https://glama.ai/mcp/servers/@RadonX/mcp-trilium">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@RadonX/mcp-trilium/badge" alt="TriliumNext MCP server" />
+</a>
+
 ## Overview
 
 This MCP server enables AI assistants like Claude to interact with your TriliumNext notes through a standardized protocol. It provides tools for creating, searching, reading, and updating notes, as well as accessing recent notes as a resource.


### PR DESCRIPTION
This PR adds a badge for the [MCP TriliumNext](https://glama.ai/mcp/servers/@RadonX/mcp-trilium) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@RadonX/mcp-trilium">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@RadonX/mcp-trilium/badge" alt="TriliumNext MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.